### PR TITLE
fix(ui): tighten tooltip claims and add Model scope and limits link

### DIFF
--- a/src/app/static/app.js
+++ b/src/app/static/app.js
@@ -2,7 +2,7 @@ const CHANNEL_REGISTRY = {
   speeds_kmh:          { label: 'Speed',             unit: 'km/h', color: '#4e9af1', group: 'Speed',       flex: 2,
     tip: 'Vehicle speed along the track, in km/h. Always non-negative.' },
   g_lat:               { label: 'Lat G',             unit: 'g',    color: '#f1a24e', group: 'G-Forces',    flex: 1,
-    tip: 'Lateral acceleration, in g. Sign follows the local track curvature. Positive in a left-hand turn, negative in a right-hand turn.' },
+    tip: 'Lateral acceleration, in g. Sign follows the local track curvature. Positive in a left-hand turn, negative in a right-hand turn. Computed from quasi-static equilibrium. Transient yaw response and counter-steer lag are not modelled.' },
   g_long:              { label: 'Long G',            unit: 'g',    color: '#e05d5d', group: 'G-Forces',    flex: 1,
     tip: 'Longitudinal acceleration, in g. Positive when accelerating along the track direction, negative when braking. Magnitudes under braking usually exceed magnitudes under acceleration because braking is tyre-limited while acceleration is power-limited.' },
   mu_util:             { label: 'Mu Utilisation',    unit: '',     color: '#d4a017', group: 'Grip',        flex: 1,
@@ -1562,6 +1562,17 @@ document.getElementById('askBtn').addEventListener('click', () => toggleChatPane
 document.getElementById('chatSubmit').addEventListener('click', sendChatMessage);
 document.getElementById('chatQuestion').addEventListener('keydown', e => {
   if (e.key === 'Enter' && !e.target.disabled) sendChatMessage();
+});
+
+function setScopeModalOpen(open) {
+  const modal = document.getElementById('scopeModal');
+  modal.classList.toggle('hidden', !open);
+}
+document.getElementById('scopeOpenBtn').addEventListener('click', () => setScopeModalOpen(true));
+document.getElementById('scopeCloseBtn').addEventListener('click', () => setScopeModalOpen(false));
+document.getElementById('scopeBackdrop').addEventListener('click', () => setScopeModalOpen(false));
+document.addEventListener('keydown', e => {
+  if (e.key === 'Escape') setScopeModalOpen(false);
 });
 
 function initInfoTips() {

--- a/src/app/static/index.html
+++ b/src/app/static/index.html
@@ -12,6 +12,7 @@
     <div class="top-bar-brand">
       <span class="page-title">Leeds Gryphon Racing Lap Time Sim</span>
       <span class="page-subtitle">Formula Student 2026</span>
+      <button type="button" class="scope-link" id="scopeOpenBtn">Model scope and limits</button>
     </div>
     <div class="top-bar-user">
       <span class="user-bar-email" id="userBarEmail"></span>
@@ -141,7 +142,7 @@
             <div class="field-hint">These are fixed by the server. Use the Tyres tab to verify the tyre model.</div>
 
             <div class="field-section-header">Solver</div>
-            <label class="field-label">Max Brake Decel <button type="button" class="info-tip" aria-label="More info" aria-hidden="true" data-tip="Cap on deceleration during braking, in g. Models real-world limits like brake pad fade or driver tolerance. Leave blank to use the server default.">i</button></label>
+            <label class="field-label">Max Brake Decel <button type="button" class="info-tip" aria-label="More info" aria-hidden="true" data-tip="User-set cap on braking deceleration, in g. Not derived from brake or pad physics. It is a solver ceiling to keep results inside a sane operating range. Leave blank to use the server default.">i</button></label>
             <input id="c-solver-max_brake_decel_g" type="text" />
             <div class="field-hint">e.g. 1.8 · g. Leave blank to use the server default.</div>
             <div class="field-checkbox-row">
@@ -419,6 +420,49 @@
     </section>
 
   </main>
+
+  <div id="scopeModal" class="scope-modal hidden" role="dialog" aria-modal="true" aria-labelledby="scopeModalTitle">
+    <div class="scope-modal-backdrop" id="scopeBackdrop"></div>
+    <div class="scope-modal-card">
+      <div class="scope-modal-header">
+        <span class="panel-label" id="scopeModalTitle">Model scope and limits</span>
+        <button type="button" class="scope-close-btn" id="scopeCloseBtn">Close</button>
+      </div>
+      <div class="scope-modal-body">
+        <p class="scope-lead">A quasi-steady-state lap time simulator built for Formula Student scale cars. It is a design trend tool, not a ground truth predictor.</p>
+
+        <div class="scope-block-label">What is modelled</div>
+        <ul class="scope-list">
+          <li>Pacejka pure-slip tyre forces with load-dependent peak</li>
+          <li>Isotropic friction ellipse for combined slip</li>
+          <li>Speed-dependent downforce and drag with a fixed centre of pressure</li>
+          <li>Quasi-static longitudinal and lateral load transfer</li>
+          <li>Engine torque curve, gearing, and traction-limited acceleration</li>
+        </ul>
+
+        <div class="scope-block-label">What is not modelled</div>
+        <ul class="scope-list">
+          <li>Transient yaw dynamics and counter-steer lag</li>
+          <li>Full Magic Formula combined-slip weighting</li>
+          <li>Tyre temperature, pressure, and relaxation length</li>
+          <li>Differential type or preload</li>
+          <li>Suspension kinematics like anti-dive, anti-squat, and camber gain</li>
+          <li>Driver behaviour. Inputs are assumed ideal</li>
+          <li>Surface roughness, wind, and weather</li>
+        </ul>
+
+        <div class="scope-block-label">Validation status</div>
+        <p class="scope-text">No telemetry comparison yet. Current trust evidence is parameter enforcement contracts and solver residual telemetry. Telemetry overlay is on the v2 roadmap. See the Validation tab.</p>
+
+        <div class="scope-block-label">Code paths</div>
+        <ul class="scope-list scope-list-code">
+          <li>src/simulator/util/calcSpeedProfile.py</li>
+          <li>src/simulator/util/vehicleDynamics.py</li>
+          <li>src/vehicle/Tyres/baseTyre.py</li>
+        </ul>
+      </div>
+    </div>
+  </div>
 
   <div id="chatPanel" class="chat-panel hidden">
     <div class="chat-panel-header">

--- a/src/app/static/styles.css
+++ b/src/app/static/styles.css
@@ -474,6 +474,112 @@ a.md-link:hover { background: #FFF0F0; }
 }
 .chat-close-btn:hover { background: #a00e25; }
 
+/* Model scope link in the top bar */
+.scope-link {
+  background: transparent;
+  border: 1px solid #A7AEB6;
+  color: #A7AEB6;
+  font-family: 'Inter', sans-serif;
+  font-size: 0.6rem;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  padding: 3px 8px;
+  cursor: pointer;
+  border-radius: 2px;
+  white-space: nowrap;
+}
+.scope-link:hover,
+.scope-link:focus-visible {
+  border-color: #006B5C;
+  color: #006B5C;
+  outline: none;
+}
+
+/* Model scope modal */
+.scope-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.scope-modal.hidden {
+  display: none;
+}
+.scope-modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(16, 18, 21, 0.55);
+}
+.scope-modal-card {
+  position: relative;
+  width: min(560px, calc(100vw - 32px));
+  max-height: calc(100vh - 64px);
+  background: #FFFFFF;
+  border: 1px solid #A7AEB6;
+  border-top: 3px solid #006B5C;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 10px 32px rgba(16, 18, 21, 0.35);
+}
+.scope-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  border-bottom: 1px solid #E8ECF0;
+  flex-shrink: 0;
+}
+.scope-close-btn {
+  background: #C1122F;
+  border: none;
+  font-family: 'Inter', sans-serif;
+  font-size: 0.65rem;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: #F4F6F8;
+  cursor: pointer;
+  padding: 5px 12px;
+}
+.scope-close-btn:hover { background: #a00e25; }
+.scope-modal-body {
+  padding: 14px 18px 18px;
+  overflow-y: auto;
+  color: #101215;
+  font-family: 'Inter', sans-serif;
+  font-size: 0.8rem;
+  line-height: 1.55;
+}
+.scope-lead {
+  margin: 0 0 14px;
+  color: #101215;
+}
+.scope-block-label {
+  font-size: 0.65rem;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  color: #006B5C;
+  margin-top: 12px;
+  margin-bottom: 6px;
+  font-weight: 700;
+}
+.scope-text {
+  margin: 0;
+}
+.scope-list {
+  margin: 0;
+  padding-left: 18px;
+}
+.scope-list li {
+  margin: 2px 0;
+}
+.scope-list-code li {
+  font-family: 'JetBrains Mono', 'Courier New', monospace;
+  font-size: 0.75rem;
+  color: #5A6470;
+}
+
 .chat-messages {
   flex: 1;
   overflow-y: auto;


### PR DESCRIPTION
## Why

Pre-LinkedIn review flagged two tooltip overclaims and a missing top-level scope statement that a senior vehicle dynamics engineer would attack first.

## What changed

**Tooltip honesty fixes**
- `Max Brake Decel` tooltip claimed the cap models brake pad fade and driver tolerance. The solver does neither. Reworded to describe it accurately as a user-set ceiling.
- `Lat G` channel tip now flags that the value comes from a quasi-static equilibrium solve and that transient yaw response and counter-steer lag are not modelled.

**Model scope and limits link**
- Small text link in the top bar, next to the page subtitle. Opens a centred modal.
- Modal content is concise. It lists what is modelled, what is not modelled, the current validation status, and the three core solver files.
- Hidden by default. The landing page stays clean.

## Files touched

- `src/app/static/index.html` link, modal markup, brake decel tooltip
- `src/app/static/app.js` Lat G channel tip, modal open and close wiring
- `src/app/static/styles.css` scope link and modal styles

## Trust check

- No new physics claims. The new copy describes what is already true of the solver.
- Copywriting rules followed. No em dash, no semicolon, no colon.
- Palette stays inside the existing chrome colours.

## Test plan

- [ ] Load the local app and confirm the `Model scope and limits` link appears in the top bar
- [ ] Click it and confirm the modal opens, lists scope, and closes via the Close button, the backdrop, and the Escape key
- [ ] Hover the `Max Brake Decel` info icon and confirm the new tooltip text reads as expected
- [ ] Hover the `Lat G` channel label in the telemetry panel and confirm the new caveat is shown

---
_Generated by [Claude Code](https://claude.ai/code/session_01W84ffdSuEvWSQWSUMXbNZj)_